### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,6 +118,9 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     needs:
       - docker
+    permissions:
+      contents: read
+      packages: write
     steps:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action


### PR DESCRIPTION
Potential fix for [https://github.com/smeetsee/csi-s3/security/code-scanning/2](https://github.com/smeetsee/csi-s3/security/code-scanning/2)

To fix the issue, we will add an explicit `permissions` block to the `merge` job. Based on the tasks performed in the job, the minimal required permissions are likely `contents: read` to access repository contents and `packages: write` to interact with Docker packages. This ensures that the job has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
