### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,7 @@
 name: Build and test
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/smeetsee/csi-s3/security/code-scanning/1](https://github.com/smeetsee/csi-s3/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only builds and tests the code, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
